### PR TITLE
fix 命令行工具生成Controller命名空间错误

### DIFF
--- a/libs/Swoole/Command/MakeController.php
+++ b/libs/Swoole/Command/MakeController.php
@@ -45,7 +45,7 @@ class MakeController extends Command
 
     static function init($name, $file)
     {
-        $code = "<?php\nnamespace App\\Controler;\n\n";
+        $code = "<?php\nnamespace App\\Controller;\n\n";
         $code .= "use Swoole\\Controller;\n\n";
         $code .= "class $name extends Controller\n{\n\n}";
         return file_put_contents($file, $code);


### PR DESCRIPTION
php console.php make:controller Test

生成的Controller文件命名空间有误导致无法访问