### PR TITLE
修改pdo在php7.1下的错误

### DIFF
--- a/libs/Swoole/Database/PdoDB.php
+++ b/libs/Swoole/Database/PdoDB.php
@@ -179,9 +179,9 @@ class PdoDB extends \PDO implements Swoole\IDatabase
 		return;
 	}
 
-    function quote($str)
+    function quote($str,$parameter_type = NULL)
     {
-        $safeStr = parent::quote($str);
+        $safeStr = parent::quote($str,$parameter_type = NULL);
         return substr($safeStr, 1, strlen($safeStr) - 2);
     }
 }


### PR DESCRIPTION
PHP7.1下使用pdo出错，显示  PdoDB:quote      should be compatible with PDO