### PR TITLE
解决无法正常使用 Redis 的 sScan scan zScan hScan 命令的问题

### DIFF
--- a/libs/Swoole/Component/Redis.php
+++ b/libs/Swoole/Component/Redis.php
@@ -135,6 +135,26 @@ class Redis
         return false;
     }
 
+    public function sScan($key, &$iterator, $pattern = '', $count = 0)
+    {
+        return $this->_redis->sScan($key,$iterator,$pattern,$count);
+    }
+
+    public function scan( &$iterator, $pattern = null, $count = 0 )
+    {
+        return $this->_redis->scan($iterator,$pattern,$count);
+    }
+
+    public function zScan($key, &$iterator, $pattern = '', $count = 0)
+    {
+        return $this->_redis->zScan($key,$iterator,$pattern,$count);
+    }
+
+    public function hScan($key, &$iterator, $pattern = '', $count = 0)
+    {
+        return $this->_redis->hScan($key,$iterator,$pattern,$count);
+    }
+
     static function write($fp, $content)
     {
         $length = strlen($content);


### PR DESCRIPTION
当调用

`
$iterator = null;
\Swoole::$php->redis->hScan('redis_key_test',$iterator);
`

报错

`PHP Warning:  Parameter 2 to Redis::hscan() expected to be a reference, value given`

导致游标无法更新。

http://php.net/manual/en/function.call-user-func-array.php
> Note
> Before PHP 5.4, referenced variables in param_arr are passed to the function by reference, regardless of whether the function expects the respective parameter to be passed by reference. This form of call-time pass by reference does not emit a deprecation notice, but it is nonetheless deprecated, and has been removed in PHP 5.4

在 PHP 5.4 以上 call_user_func_array  已经不支持引用变量