### PR TITLE
fix db model get func invalid problem

### DIFF
--- a/libs/Swoole/SelectDB.php
+++ b/libs/Swoole/SelectDB.php
@@ -107,6 +107,7 @@ class SelectDB
             $this->use_index='';
             $this->join='';
             $this->union='';
+            $this->is_execute = 0;
         }
         else
         $this->$what = '';


### PR DESCRIPTION
- 问题：同一个请求中一次以上调用 `\Swoole::$php->db->get()` 方法时从第二次开始会获取不到数据
- 原因：`get` 方法中的 `init` 方法未重置变量 `is_execute` 导致后续调用会跳过 `execute` 方法
- 解决：在 `init` 方法中重置变量 `is_execute` 为 `0`